### PR TITLE
add filter for option autoload parameter

### DIFF
--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -181,7 +181,9 @@ function pmpro_saveSetExpirationDate($level_id, $set_expiration_date, $code_id =
         $key = "pmprosed_" . $level_id;
     }
 
-    update_option($key, $set_expiration_date);
+    $autoload = apply_filters( 'pmprosed_option_autoload', null );
+
+    update_option($key, $set_expiration_date, $autoload);
 }
 
 /*


### PR DESCRIPTION
The plugin sets one option per level and discount code that are autoloaded on every requests.

This unfortunately doesn't scale well with my project that has a lot of discount codes.

This pull request adds a filter that gives people the option to disable autoload on this option.

Should we have `false` as default for this filter? This option doesn't seem to be used a lot.

Thanks,





