### PR TITLE
Feature: Extend membership if existing level present

### DIFF
--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -4,7 +4,7 @@
 Plugin Name: Paid Memberships Pro - Set Expiration Dates Add On
 Plugin URI: http://www.paidmembershipspro.com/wp/pmpro-set-expiration-dates/
 Description: Set a specific expiration date (e.g. 2013-12-31) for a PMPro membership level or discount code. 
-Version: .3
+Version: .3.1
 Author: Stranger Studios
 Author URI: http://www.strangerstudios.com
 */
@@ -168,7 +168,82 @@ function pmprosed_pmpro_checkout_level($level, $discount_code_id = null)
 }
 add_filter("pmpro_checkout_level", "pmprosed_pmpro_checkout_level");
 add_filter('pmpro_discount_code_level', 'pmprosed_pmpro_checkout_level', 10, 2);
-add_filter('pmpro_ipnhandler_level', 'pmprosed_pmpro_checkout_level');
+
+/*
+	Update expiration date of level during IPN requests
+	NB almost identical to previous function EXCEPT uses different arguments
+	Does not currently change any functionality, but allows later modifications that rely on knowing the $user_id during an IPN request
+*/
+function pmprosed_pmpro_ipnhandler($level, $user_id)
+{
+    global $wpdb;
+
+	// removed first mention of $discount_code_id here as it is not passed to this function
+	// unsure if $_REQUEST is ever used with IPN??
+	// Left this section in in case it is (aquiferweb)
+    if (!empty($_REQUEST['discount_code'])) {
+        //get discount code passed in
+        $discount_code = preg_replace("/[^A-Za-z0-9\-]/", "", $_REQUEST['discount_code']);
+        if (!empty($discount_code)) {
+            $discount_code_id = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql($discount_code) . "' LIMIT 1");
+        } else {
+            $discount_code_id = NULL;
+        }
+    }else{
+		$discount_code_id = NULL;
+	}
+
+    //does this level have a set expiration date?
+    $set_expiration_date = pmpro_getSetExpirationDate($level->id, $discount_code_id);
+
+    //check for Y
+    if (strpos($set_expiration_date, "Y") !== false) {
+        $used_y = true;
+    }
+
+    if (!empty($set_expiration_date)) {
+        //replace vars
+        $set_expiration_date = pmprosed_fixDate($set_expiration_date);
+
+        //how many days until expiration
+        $todays_date = time();
+        $time_left = strtotime($set_expiration_date) - $todays_date;
+        if ($time_left > 0) {
+            $days_left = ceil($time_left / (60 * 60 * 24));
+
+            //update number and period
+            $level->expiration_number = $days_left;
+            $level->expiration_period = "Day";
+
+            return $level;    //stop
+        } elseif (!empty($used_y)) {
+            $timestamp = strtotime($set_expiration_date);
+
+            //add one year to expiration date
+            $set_expiration_date = date("Y-m-d", mktime(0, 0, 0, date('m', $timestamp), date('d', $timestamp), date('Y', $timestamp) + 1));
+
+            //how many days until expiration
+            $time_left = strtotime($set_expiration_date) - $todays_date;
+            $days_left = ceil($time_left / (60 * 60 * 24));
+
+            //update number and period
+            $level->expiration_number = $days_left;
+            $level->expiration_period = "Day";
+
+            return $level; //stop
+        } else {
+            //expiration already here, don't let people signup
+            $level = NULL;
+
+            return $level; //stop
+        }
+    }
+
+    return $level;    //no change
+}
+
+// added priority and number of variables here
+add_filter('pmpro_ipnhandler_level', 'pmprosed_pmpro_ipnhandler',15,2);
 
 /*	
 	This function will save a the set expiration dates into wp_options.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: strangerstudios
 Tags: paid memberships pro, pmpro, memberships, ecommerce, expiration
 Requires at least: 3.5
 Tested up to: 4.5.3
-Stable tag: .3
+Stable tag: .3.1
 
 Set a specific expiration date (e.g. 2013-12-31) for a PMPro membership level or discount code in YYYY-MM-DD format.
 Enter "Y" for current year, "Y2" for next year. "M", "M2" for current/next month.
@@ -17,10 +17,13 @@ This plugin requires Paid Memberships Pro to function.
 == Installation ==
 
 1. Upload the `pmpro-set-expiration-date` directory to the `/wp-content/plugins/` directory of your site.
-1. Activate the plugin through the 'Plugins' menu in WordPress.
-1. Change the expiration date on the edit levels and edit discount code pages.
+2. Activate the plugin through the 'Plugins' menu in WordPress.
+3. Change the expiration date on the edit levels and edit discount code pages.
 
 == Changelog ==
+= .3.1 = 
+* BUG: fixed bug - added new function pmprosed_pmpro_ipnhandler that filters IPNs to allow access to $user_id
+
 = .3 =
 * BUG: Fixed bug when using PayPal Standard.
 * BUG: Fixed bug with dates near the end of the month.

--- a/readme.txt
+++ b/readme.txt
@@ -3,13 +3,15 @@ Contributors: strangerstudios
 Tags: paid memberships pro, pmpro, memberships, ecommerce, expiration
 Requires at least: 3.5
 Tested up to: 4.5.3
-Stable tag: .3.1
+Stable tag: .3.2
 
 Set a specific expiration date (e.g. 2013-12-31) for a PMPro membership level or discount code in YYYY-MM-DD format.
 Enter "Y" for current year, "Y2" for next year. "M", "M2" for current/next month.
 If the expiration date has already passed and "Y" is used, "Y" will start at the next year.
 
 This expiration date will override any expiration period set on the level.
+
+If a user already has an active membership on this level, this plugin attempts to extend their existing expiry date, rather than setting expiry dates based on the current time.
 
 == Description ==
 This plugin requires Paid Memberships Pro to function.
@@ -21,6 +23,9 @@ This plugin requires Paid Memberships Pro to function.
 3. Change the expiration date on the edit levels and edit discount code pages.
 
 == Changelog ==
+= .3.2 =
+* Attempts to extend an existing membership level (if present) rather than always working from current time.
+
 = .3.1 = 
 * BUG: fixed bug - added new function pmprosed_pmpro_ipnhandler that filters IPNs to allow access to $user_id
 


### PR DESCRIPTION
This relies on a fix for issue 13.
I've attempted to check for an existing membership level, and if it exists, to base the expiry date calculation on the existing expiry date, rather than always basing it on the current time.
I'm unsure about two things:
- whether this plays nicely with discount code features
- whether the tweak I added regarding dates at the end of the month (line 401) is necessary or useful to anyone else.