### PR TITLE
Updating priority of level settings to be close as possible to core expiration setting fields

### DIFF
--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -46,7 +46,7 @@ function pmprosed_pmpro_membership_level_after_other_settings()
     </table>
     <?php
 }
-add_action("pmpro_membership_level_after_other_settings", "pmprosed_pmpro_membership_level_after_other_settings");
+add_action( 'pmpro_membership_level_after_other_settings', 'pmprosed_pmpro_membership_level_after_other_settings', 1 );
 
 //save level cost text when the level is saved/added
 function pmprosed_pmpro_save_membership_level($level_id)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The core PMPro "Membership Expiration" setting fields are the last element before the hook to add other settings used by this Add On and others. This PR moves the Set Expiration Date settings to load at priority 1 on that hook (every other Add Ons appears to just hook at the 10 priority).

### How to test the changes in this Pull Request:

1. Have this plugin active alongside Register Helper or another Add On that adds to this hook: pmpro_membership_level_after_other_settings
2. See that without this PR, other Add Ons may have their settings before this one's 
3. See that with this PR, the "Set Expiration Date" fields come right after the "Member Expiration" setting on core PMPro. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
