### PR TITLE
Adjusting warning message for past expiration dates.

### DIFF
--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -335,8 +335,6 @@ add_action( 'pmpro_membership_levels_table_extra_cols_body', 'pmprosed_membershi
  * @since 0.6
  */
 function pmprosed_show_admin_notice_past_dates() {
-    global $msg, $msgt;
-
     // get all levels
     $levels = pmpro_getAllLevels(true,false);
 
@@ -345,17 +343,20 @@ function pmprosed_show_admin_notice_past_dates() {
     foreach( $levels as $level ) {
        if ( $level->allow_signups && pmprosed_is_past_date( $level->id ) ) {
            $is_past = true;
-           $problem_levels[$level->id] = $level->id;
+           $problem_levels[$level->id] = '<a href="' . add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'edit' => $level->id ), admin_url( 'admin.php' ) ) . '">' . $level->name . '</a>';
        }
     }
 
     // Get all levels and their dates.
     if ( $is_past ) {
 
-        $levels = implode(', ', $problem_levels );
-
-        $msg = -1;
-        $msgt = sprintf( __( "Warning: The following level(s) have a past expiration date: <strong>ID's - %s</strong>.", 'pmpro-set-expiration-dates' ), $levels );
+        $levels = implode(', ', $problem_levels ); ?>
+		<div class="notice notice-warning">
+			<p><?php
+				echo sprintf(__( '<strong>Warning:</strong> The following membership levels have an expiration date that is in the past: %s.', 'pmpro-set-expiration-dates' ), $levels );
+			?></p>
+		</div>
+		<?php
     }
 }
 if ( isset( $_REQUEST['page'] ) && 'pmpro-membershiplevels' == $_REQUEST['page'] && ! isset( $_REQUEST['edit'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adjustment to the warning message when one or more levels have incorrect expiration date settings.

### How to test the changes in this Pull Request:

1. Set a level to have an expiration date in the past.
2. View the Memberships > Settings > Levels page in the WordPress admin.
3. The warning should appear as this screenshot:

<img width="1181" alt="Screen Shot 2020-09-15 at 11 58 25 AM" src="https://user-images.githubusercontent.com/5312875/93236455-dc128d80-f74c-11ea-82a8-b072d5aa6a06.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
