### PR TITLE
Fixing use of $level_id where should be the full $level object

### DIFF
--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -229,7 +229,7 @@ add_filter('pmpro_discount_code_level', 'pmprosed_pmpro_checkout_level', 10, 2);
  * @since 0.6
  */
 function pmprosed_pmpro_ipnhandler_level( $level, $user_id = null) {
-    return pmprosed_pmpro_checkout_level( $level_id, null );
+    return pmprosed_pmpro_checkout_level( $level, null );
 }
 add_filter( 'pmpro_ipnhandler_level', 'pmprosed_pmpro_ipnhandler_level', 10, 2 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes issue https://github.com/strangerstudios/pmpro-set-expiration-dates/issues/30
