### PR TITLE
We should always use current_time('timestamp') instead of time()

### DIFF
--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -185,7 +185,7 @@ function pmprosed_pmpro_checkout_level($level, $discount_code_id = null)
         $set_expiration_date = pmprosed_fixDate($set_expiration_date);
 
         //how many days until expiration
-        $todays_date = time();
+        $todays_date = current_time( 'timestamp' );
         $time_left = strtotime($set_expiration_date) - $todays_date;
         if ($time_left > 0) {
             $days_left = ceil($time_left / (60 * 60 * 24));


### PR DESCRIPTION
In this case expiration dates can end up 1 day short if within $offset hours of midnight.

Updated to use current_time( 'timestamp' ) instead of time()

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #36 .

### How to test the changes in this Pull Request:

1. Set server time to 8:15pm ET
2. Set expiration date to Y-07-31
3. Check out and note that the expiration date is the 30th before this fix, the 31st after.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed issue where expiration dates were sometimes 1 day early.
