### PR TITLE
Move to "Expiration Settings"

### DIFF
--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -19,8 +19,10 @@ add_action( 'init', 'pmprosed_load_plugin_text_domain' );
 /*
 	This first set of functions adds our fields to the edit membership levels page
 */
-// add level cost text field to level price settings
-function pmprosed_pmpro_membership_level_after_other_settings() {
+/**
+ * Add Set Expiration Date settings to the Expirations tab of the edit level settings.
+ */
+function pmprosed_pmpro_membership_level_after_expiration_settings() {
 	$level_id = intval( $_REQUEST['edit'] );
 	if ( $level_id > 0 ) {
 		$set_expiration_date = pmpro_getSetExpirationDate( $level_id );
@@ -45,7 +47,7 @@ function pmprosed_pmpro_membership_level_after_other_settings() {
 	</table>
 	<?php
 }
-add_action( 'pmpro_membership_level_after_other_settings', 'pmprosed_pmpro_membership_level_after_other_settings', 1 );
+add_action( 'pmpro_membership_level_after_expiration_settings', 'pmprosed_pmpro_membership_level_after_expiration_settings', 1 );
 
 // save level cost text when the level is saved/added
 function pmprosed_pmpro_save_membership_level( $level_id ) {


### PR DESCRIPTION
* ENHANCEMENT: Move the settings to the "Expiration Settings" of the edit membership level page.

Resolves: https://github.com/strangerstudios/pmpro-set-expiration-dates/issues/35

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


Screenshot:
![Screenshot 2024-04-24 at 12 14 25](https://github.com/strangerstudios/pmpro-set-expiration-dates/assets/12629136/793c0e74-68f1-4b75-8edb-2601b6186108)
