### PR TITLE
Fix for discount code settings not overriding level settings

### DIFF
--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -163,9 +163,9 @@ function pmprosed_pmpro_checkout_level( $level, $discount_code_id = null ) {
 		return $level;
 	}
 
-	if ( empty( $discount_code_id ) && ! empty( $_REQUEST['discount_code'] ) ) {
+	if ( empty( $discount_code_id ) && ! empty( $_REQUEST['pmpro_discount_code'] ) ) {
 		// get discount code passed in
-		$discount_code = preg_replace( '/[^A-Za-z0-9\-]/', '', $_REQUEST['discount_code'] );
+		$discount_code = preg_replace( '/[^A-Za-z0-9\-]/', '', $_REQUEST['pmpro_discount_code'] );
 
 		if ( ! empty( $discount_code ) ) {
 			$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
@@ -450,3 +450,4 @@ function pmprosed_pmpro_level_expiration_text( $expiration_text, $level ) {
 	return $expiration_text;
 }
 add_filter( 'pmpro_level_expiration_text', 'pmprosed_pmpro_level_expiration_text', 10, 2 );
+

--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -163,14 +163,25 @@ function pmprosed_pmpro_checkout_level( $level, $discount_code_id = null ) {
 		return $level;
 	}
 
-	if ( empty( $discount_code_id ) && ! empty( $_REQUEST['pmpro_discount_code'] ) ) {
-		// get discount code passed in
-		$discount_code = preg_replace( '/[^A-Za-z0-9\-]/', '', $_REQUEST['pmpro_discount_code'] );
+	if ( empty( $discount_code_id ) ) {
+		// get discount code passed in, supporting multiple request keys for backward compatibility
+		$raw_discount_code = '';
+		if ( ! empty( $_REQUEST['pmpro_discount_code'] ) ) {
+			$raw_discount_code = $_REQUEST['pmpro_discount_code'];
+		} elseif ( ! empty( $_REQUEST['discount_code'] ) ) {
+			$raw_discount_code = $_REQUEST['discount_code'];
+		} elseif ( ! empty( $_REQUEST['code'] ) ) {
+			$raw_discount_code = $_REQUEST['code'];
+		}
 
-		if ( ! empty( $discount_code ) ) {
-			$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
-		} else {
-			$discount_code_id = null;
+		if ( ! empty( $raw_discount_code ) ) {
+			$discount_code = preg_replace( '/[^A-Za-z0-9\-]/', '', $raw_discount_code );
+
+			if ( ! empty( $discount_code ) ) {
+				$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
+			} else {
+				$discount_code_id = null;
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The discount code request parameter has a `pmpro` prefix since 3.0.
Updating the `pmpro_checkout_level` callback with the `pmpro_discount_code` request parameter. 
Ensures expiration dates from discount codes are applied to the level at checkout.

Resolves #49 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed issue where expiration dates in discount codes may not be applied.
