### PR TITLE
Improve support for PBC

### DIFF
--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -238,7 +238,7 @@ add_filter( 'pmpro_payfast_itnhandler_level', 'pmprosed_pmpro_ipnhandler_level',
 add_filter( 'pmpro_paystack_webhook_level', 'pmprosed_pmpro_ipnhandler_level', 10, 2 );
 
 /**
- * Add support for gateways that may process the order later. Like Pay By Check
+ * Add support for gateways that may process the order later (manual payments). Like Pay By Check
  * 
  * @since TBD
  */
@@ -265,9 +265,18 @@ function pmprosed_force_set_expiration_enddate( $enddate, $user_id, $level, $sta
 	if ( ! empty( $level->discount_code ) ) {
 		// Prefer the discount code attached to the level object.
 		$local_discount_code = $level->discount_code;
-		$local_discount_code_id = empty( $level->code_id )
-			? $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $local_discount_code ) . "' LIMIT 1" )
-			: $level->code_id;
+
+		// The discount_code_id logic.
+		if ( empty( $level->code_id ) ) {
+ 			$local_discount_code_id = $wpdb->get_var(
+ 				$wpdb->prepare(
+ 					"SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = %s LIMIT 1",
+ 					$local_discount_code
+ 				)
+ 			);
+ 		} else {
+ 			$local_discount_code_id = $level->code_id;
+ 		}
 	} elseif ( ! empty( $discount_code ) ) {
 		// Fall back to the global discount code, if available.
 		$local_discount_code = $discount_code;
@@ -276,14 +285,30 @@ function pmprosed_force_set_expiration_enddate( $enddate, $user_id, $level, $sta
 			$local_discount_code_id = $discount_code_id;
 		} else {
 			// Otherwise, look up the ID based on the global discount code.
-			$local_discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $local_discount_code ) . "' LIMIT 1" );
+			$local_discount_code_id = $wpdb->get_var(
+ 			$wpdb->prepare(
+ 				"SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = %s LIMIT 1",
+ 				$discount_code
+ 			)
+ 		);
 		}
 	}
 
 	// Does this particular level have a set expiration date.
 	$set_expiration_date = pmpro_getSetExpirationDate( $level->id, $local_discount_code_id );
+
+	// Make sure we got the right timestamp.
+	$startdate_timestamp = null;
+	if ( ! empty( $startdate ) ) {
+		if ( is_numeric( $startdate ) ) {
+			$startdate_timestamp = (int) $startdate;
+		} else {
+			$startdate_timestamp = strtotime( $startdate );
+		}
+	}
+
 	if ( ! empty( $set_expiration_date ) ) {
-		$enddate = pmprosed_fixDate( $set_expiration_date );
+		$enddate = pmprosed_fixDate( $set_expiration_date, $startdate_timestamp );
 	}
 
 	return $enddate;

--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -257,17 +257,31 @@ function pmprosed_force_set_expiration_enddate( $enddate, $user_id, $level, $sta
 	// Try to get the discount code ID if one is being used, this is similar to the checkout.php logic.
 	// Using the $discount_code_id global as a fallback for backwards compatibility - this should always be attached to the level object.
 	global $wpdb, $discount_code, $discount_code_id;
+
+	// Use local variables to avoid mutating globals.
+	$local_discount_code     = null;
+	$local_discount_code_id  = null;
+
 	if ( ! empty( $level->discount_code ) ) {
-		$discount_code = $level->discount_code;
-		$discount_code_id = empty( $level->code_id ) ? $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" ) : $level->code_id;
-	} elseif ( ! empty( $discount_code ) && empty( $discount_code_id ) ) {
-		$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
-	} else {
-		$discount_code_id = null;
+		// Prefer the discount code attached to the level object.
+		$local_discount_code = $level->discount_code;
+		$local_discount_code_id = empty( $level->code_id )
+			? $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $local_discount_code ) . "' LIMIT 1" )
+			: $level->code_id;
+	} elseif ( ! empty( $discount_code ) ) {
+		// Fall back to the global discount code, if available.
+		$local_discount_code = $discount_code;
+		if ( ! empty( $discount_code_id ) ) {
+			// If a global discount code ID is already set, use it.
+			$local_discount_code_id = $discount_code_id;
+		} else {
+			// Otherwise, look up the ID based on the global discount code.
+			$local_discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $local_discount_code ) . "' LIMIT 1" );
+		}
 	}
 
 	// Does this particular level have a set expiration date.
-	$set_expiration_date = pmpro_getSetExpirationDate( $level->id, $discount_code_id );
+	$set_expiration_date = pmpro_getSetExpirationDate( $level->id, $local_discount_code_id );
 	if ( ! empty( $set_expiration_date ) ) {
 		$enddate = pmprosed_fixDate( $set_expiration_date );
 	}

--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -237,6 +237,32 @@ add_filter( 'pmpro_ipnhandler_level', 'pmprosed_pmpro_ipnhandler_level', 10, 2 )
 add_filter( 'pmpro_payfast_itnhandler_level', 'pmprosed_pmpro_ipnhandler_level', 10, 2 );
 add_filter( 'pmpro_paystack_webhook_level', 'pmprosed_pmpro_ipnhandler_level', 10, 2 );
 
+/**
+ * Force the Set Expiration Date to be applied, even if the IPN/webhook/PBC order is processed on a different day.
+ * 
+ * @since TBD
+ */
+function pmprosed_force_set_expiration_enddate( $enddate, $user_id, $level, $startdate ) {
+
+	// Bail if no enddate or a NULL enddate.
+	if ( $enddate === "NULL" || empty( $enddate ) ) {
+		return $enddate;
+	}
+
+	// No level found, bail.
+	if ( empty( $level ) || empty( $level->id ) ) {
+		return $enddate;
+	}
+
+	// Does this level have a set expiration date?
+	$set_expiration_date = pmpro_getSetExpirationDate( $level->id );
+	if ( ! empty( $set_expiration_date ) ) {
+		$enddate = pmprosed_fixDate( $set_expiration_date );
+	}
+
+	return $enddate;
+}
+add_filter( 'pmpro_checkout_end_date', 'pmprosed_force_set_expiration_enddate', 10, 4 );
 
 /*
 	This function will save a the set expiration dates into wp_options.

--- a/pmpro-set-expiration-dates.php
+++ b/pmpro-set-expiration-dates.php
@@ -238,7 +238,7 @@ add_filter( 'pmpro_payfast_itnhandler_level', 'pmprosed_pmpro_ipnhandler_level',
 add_filter( 'pmpro_paystack_webhook_level', 'pmprosed_pmpro_ipnhandler_level', 10, 2 );
 
 /**
- * Force the Set Expiration Date to be applied, even if the IPN/webhook/PBC order is processed on a different day.
+ * Add support for gateways that may process the order later. Like Pay By Check
  * 
  * @since TBD
  */
@@ -254,8 +254,20 @@ function pmprosed_force_set_expiration_enddate( $enddate, $user_id, $level, $sta
 		return $enddate;
 	}
 
-	// Does this level have a set expiration date?
-	$set_expiration_date = pmpro_getSetExpirationDate( $level->id );
+	// Try to get the discount code ID if one is being used, this is similar to the checkout.php logic.
+	// Using the $discount_code_id global as a fallback for backwards compatibility - this should always be attached to the level object.
+	global $wpdb, $discount_code, $discount_code_id;
+	if ( ! empty( $level->discount_code ) ) {
+		$discount_code = $level->discount_code;
+		$discount_code_id = empty( $level->code_id ) ? $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" ) : $level->code_id;
+	} elseif ( ! empty( $discount_code ) && empty( $discount_code_id ) ) {
+		$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
+	} else {
+		$discount_code_id = null;
+	}
+
+	// Does this particular level have a set expiration date.
+	$set_expiration_date = pmpro_getSetExpirationDate( $level->id, $discount_code_id );
 	if ( ! empty( $set_expiration_date ) ) {
 		$enddate = pmprosed_fixDate( $set_expiration_date );
 	}


### PR DESCRIPTION
* ENHANCEMENT: Force the Set Expiration Date Add On date to apply for any gateway that may process checkout on a different day.

Resolves: https://github.com/strangerstudios/pmpro-pay-by-check/issues/137 (Pay By Check issue)

This is a difficult decision, but it does make sense to force the Set Expiration Date and should not be used if you are concerned in members may lose time in cases like Pay By Check orders being processed by a human a couple of days later. This caters for sites that always want the expiration date to be that of the Set Expiration Date value - regardless of when the payment/checkout is actually processed (i.e. a few days after initial checkout).

This can easily be unhooked by removing the hook in a custom code snippet or do not use it for a specific payment option (check payments or any other manual payment gateway).

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:

1. Adjust the enddate inside the pmpro_complete_checkout to be a hardcoded date (https://github.com/strangerstudios/paid-memberships-pro/blob/846910e942398d7c43e3b6b3dd661b270e2e5439/includes/checkout.php#L211)
2. Checkout using a one-time level, with expiration date AND Set Expiration Date enabled and configured for this level.
3. Mark the order as "success" and see that the expiration date is the Set Expiration Date value set. (i.e. 2025-12-31)

Test the same steps before pulling this PR to see that the date of process/applied in the pmpro_complete_checkout overrides the Set Expiration Date.
